### PR TITLE
Fix builds on MacOS, and other fixes

### DIFF
--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -52,23 +52,13 @@ void exec(Token* tokens) {
         strncpy(glob + 9, command.value, strlen(command.value) + 1);
 
         int err = fileExists(glob, &stats);
-        if (err) {
-            printFileErr(err, command.value);
-            state.lastResult = 127;
-            setLastResult("127", 3);
-            return;
-        } else if (!(stats.st_mode & X_OK)) {
+        if (!err && !(stats.st_mode & X_OK)) {
             fprintf(stderr, "ash: Unknown command. '%s' exists but does not have execute permissions.\n", command.value);
             return;
         }
     } else {
         int err = fileExists(command.value, &stats);
-        if (err) {
-            printFileErr(err, command.value);
-            state.lastResult = 127;
-            setLastResult("127", 3);
-            return;
-        } else if (!(stats.st_mode & X_OK)) {
+        if (!err && !(stats.st_mode & X_OK)) {
             fprintf(stderr, "ash: Unknown command. '%s' exists but does not have execute permissions.\n", command.value);
             return;
         }

--- a/src/repl/print_signal.c
+++ b/src/repl/print_signal.c
@@ -30,11 +30,11 @@ void printSignal(int sig) {
 		case SIGPIPE:
 			printLit("Broken pipe");
 			break;
-		default:
-            char buf[4];
-            snprintf(buf, 4, "%i", sig);
+		default:;
+			char buf[4];
+			snprintf(buf, 4, "%i", sig);
 			printLit("Killed by unhandled signal ");
-            print(buf, 4);
+			print(buf, 4);
 			break;
 	}
 }

--- a/src/repl/write.c
+++ b/src/repl/write.c
@@ -84,7 +84,7 @@ void draw(char* str, size_t length) {
 
     if (length > state.pos) {
         char buf[32];
-        snprintf(buf, sizeof(buf), "\x1b[%dD", length - state.pos);
+        snprintf(buf, sizeof(buf), "\x1b[%zuD", length - state.pos);
         printLit(buf);
     }
 


### PR DESCRIPTION
- Fix compilation with Clang on MacOS
- Use %zu instead of %d for argument of type size_t
- Don’t check if file exists before executing
